### PR TITLE
feat(install): :package: remove generic mapper if installed

### DIFF
--- a/PRS.lua
+++ b/PRS.lua
@@ -1,5 +1,10 @@
 -- Procedural Realms Script (PRS) by Stack
-local version = "0.10.2"
+local version = "0.11.0"
+
+-- check if the generic_mapper package is installed and, if so, uninstall it
+if table.contains(getPackages(),"generic_mapper") then
+  uninstallPackage("generic_mapper")
+end
 
 -- Open the windows
 PRSchat.tabs()


### PR DESCRIPTION
generic_Mapper is installed by default with mudlet. it doesn't work with PR, so there's no need for it