### PR TITLE
Fixing #41 - copy and paste error from make_room to handle_move resul…

### DIFF
--- a/prs-mapper.lua
+++ b/prs-mapper.lua
@@ -180,7 +180,7 @@ local function handle_move()
       local exit_coords_delta = move_vectors[stubmap[v]]
       local exit_room_id = get_room_id_by_coordinates(info.area, coords[1] + exit_coords_delta[1], coords[2] + exit_coords_delta[2], coords[3] + exit_coords_delta[3])
       if exit_room_id ~= nill then
-        connectExitStub(room_id, dir)
+        connectExitStub(room_id, v)
       end
     end
   end


### PR DESCRIPTION
…ting in runtime error

Fixed #41 by passing the direction id into ConnectExitStub rather than a non-existent value.