### PR TITLE
Adds logic for instanced areas

### DIFF
--- a/prs-mapper.lua
+++ b/prs-mapper.lua
@@ -342,7 +342,7 @@ function map.eventHandler(event,...)
         for k,v in pairs(map.room_info.exits) do
             map.room_info.exits[k] = tonumber(v)
         end
-        if map.prev_info.area ~= map.room_info.area then
+        if map.prev_info.area and (map.prev_info.area ~= map.room_info.area) then
           if gmcp.room.info.instanced then
             deleteArea(gmcp.room.info.zone)
           end

--- a/prs-mapper.lua
+++ b/prs-mapper.lua
@@ -328,6 +328,7 @@ end
 
 function map.eventHandler(event,...)
     if event == "gmcp.room.info" then
+	if gmcp.room.info.zone == "Battlefield" then return end
         map.prev_info = map.room_info
         map.room_info = {
           vnum = gmcp.room.info.num,
@@ -340,6 +341,11 @@ function map.eventHandler(event,...)
         }
         for k,v in pairs(map.room_info.exits) do
             map.room_info.exits[k] = tonumber(v)
+        end
+        if map.prev_info.area ~= map.room_info.area then
+          if gmcp.room.info.instanced then
+            deleteArea(gmcp.room.info.zone)
+          end
         end
         handle_move()
     elseif event == "shiftRoom" then


### PR DESCRIPTION
Calls to deleteArea when switching to a new zone if that zone is "instanced".  There may be instances where this is incorrect, but I haven't run into any since adding the logic for ignoring "Battlefield".