### PR TITLE
fix(chat): 🐛 Change to line-based triggers for chat capture (#44)

### DIFF
--- a/prs-chat.lua
+++ b/prs-chat.lua
@@ -1,4 +1,6 @@
 PRSchat = PRSchat or {}
+PRSchat.triggers = PRSchat.triggers or {}
+
 function PRSchat.tabs()
   local EMCO = require("PRS.emco")
   PRSchat.UW = Geyser.UserWindow:new({name = "Chat", titleText ="Procedural Realms", y="50%", docked = true})
@@ -30,3 +32,104 @@ function PRSchat.tabs()
     preserveBackground = true,
   }, PRSchat.UW)
 end
+
+
+function PRSchat.stop()
+  for k, v in pairs(PRSchat.triggers) do
+    killTrigger(v)
+  end
+  
+  return true
+end
+
+function PRSchat.initialize()
+  if not PRSchat.triggers.chat_trigger_id then
+    PRSchat.triggers.chat_trigger_id = tempRegexTrigger("^< Chat \\| (?<sender>.+) > (?<msg>.+)$", function()
+      local chat_lines = {}
+  
+      PRSchat.triggers.chat_line_id = tempRegexTrigger(".*", function()
+        if isPrompt() then
+          local concat_lines = table.concat(chat_lines)
+          local result = concat_lines:sub(1, -2).."\n"
+  
+          PRSchat.EMCO:decho("Chat", result, false)
+          killTrigger(PRSchat.triggers.chat_line_id)
+        else
+          table.insert(chat_lines, copy2decho().." ")
+        end
+      end)
+    end)
+  end
+
+  if not PRSchat.triggers.newbie_trigger_id then
+    PRSchat.triggers.newbie_trigger_id = tempRegexTrigger("^< Newbie \\| (?<sender>.+) > (?<msg>.+)$", function()
+      local chat_lines = {}
+  
+      PRSchat.triggers.newbie_line_id = tempRegexTrigger(".*", function()
+        if isPrompt() then
+          local concat_lines = table.concat(chat_lines)
+          local result = concat_lines:sub(1, -2).."\n"
+  
+          PRSchat.EMCO:decho("Newbie", result, false)
+          killTrigger(PRSchat.triggers.newbie_line_id)
+        else
+          table.insert(chat_lines, copy2decho().." ")
+        end
+      end)
+    end)
+  end
+
+  if not PRSchat.triggers.trade_trigger_id then
+    PRSchat.triggers.trade_trigger_id = tempRegexTrigger("^< Trade \\| (?<sender>.+) > (?<msg>.+)$", function()
+      local chat_lines = {}
+  
+      PRSchat.triggers.trade_line_id = tempRegexTrigger(".*", function()
+        if isPrompt() then
+          local concat_lines = table.concat(chat_lines)
+          local result = concat_lines:sub(1, -2).."\n"
+  
+          PRSchat.EMCO:decho("Trade", result, false)
+          killTrigger(PRSchat.triggers.trade_line_id)
+        else
+          table.insert(chat_lines, copy2decho().." ")
+        end
+      end)
+    end)
+  end
+
+  if not PRSchat.triggers.local_trigger_id then
+    PRSchat.triggers.local_trigger_id = tempRegexTrigger("^(?<sender>.+) say(?<s>s)?, '(?<msg>.+)$", function()
+      local chat_lines = {}
+  
+      PRSchat.triggers.local_line_id = tempRegexTrigger(".+", function()
+        table.insert(chat_lines, copy2decho().." ")
+        if string.ends(line, "'") then
+          local concat_lines = table.concat(chat_lines)
+          local result = concat_lines:sub(1, -2).."\n"
+  
+          PRSchat.EMCO:decho("Local", result, false)
+          killTrigger(PRSchat.triggers.local_line_id)
+        end
+      end)
+    end)
+  end
+
+  if not PRSchat.triggers.tell_trigger_id then
+    PRSchat.triggers.tell_trigger_id = tempRegexTrigger("^(?<from>.+) tell(?<s>s)? (?<to>\\w+), '(?<msg>.+)$", function()
+      local chat_lines = {}
+  
+      PRSchat.triggers.tell_line_id = tempRegexTrigger(".+", function()
+        table.insert(chat_lines, copy2decho().." ")
+        if string.ends(line, "'") then
+          local concat_lines = table.concat(chat_lines)
+          local result = concat_lines:sub(1, -2).."\n"
+  
+          PRSchat.EMCO:decho("Tell", result, false)
+          killTrigger(PRSchat.triggers.tell_line_id)
+        end
+      end)
+    end)
+  end
+end
+
+PRSchat.initialize()


### PR DESCRIPTION
Moving to line-based triggers for chat capture

This addresses #4 and was tested for a week. Initially it there was mudlet crash potential and strange echo of chats and events, which seem to have been server-related and absolved after changes to GA on server side.