### PR TITLE
Improve Chat and Stats by retaining position and adding command lines

### DIFF
--- a/PRS.lua
+++ b/PRS.lua
@@ -7,8 +7,8 @@ if table.contains(getPackages(),"generic_mapper") then
 end
 
 -- Open the windows
+PRSchat.tabs()
 registerAnonymousEventHandler("gmcp.Char.player", function()
-  PRSchat.tabs()
   PRSstats.stats()
 end, true)
 

--- a/prs-chat.lua
+++ b/prs-chat.lua
@@ -9,6 +9,7 @@ function PRSchat.tabs()
     title_text = "Procedural Realms - "..gmcp.Char.player.name
   else
     title_text = "Procedural Realms"
+    registerAnonymousEventHandler("gmcp.Char.player.name", function() PRSchat.UW:setTitle("Procedural Realms - "..gmcp.Char.player.name) end, true)
   end
   
   PRSchat.UW = Geyser.UserWindow:new({name = "Chat", titleText = title_text, y="50%", docked = true, width="25%", height="75%"})

--- a/prs-stats.lua
+++ b/prs-stats.lua
@@ -220,26 +220,21 @@ local function add_gauges()
         padding-left: 5px;
       ]])
       
-      echo("reaching first handler registration\n")
       if PRSstats.events.xp_id then killAnonymousEventHandler(PRSstats.events.xp_id) end
       PRSstats.events.xp_id = registerAnonymousEventHandler("gmcp.Char.player.xp", function()
         PRSstats.xp.current = gmcp.Char.player.xp - gmcp.Char.player.xpForCurrentLevel
       end)
       
-      echo("reaching second handler registration\n")
       if PRSstats.events.xpForCurrentLevel_id then killAnonymousEventHandler(PRSstats.events.xpForCurrentLevel_id) end
       PRSstats.events.xpForCurrentLevel_id = registerAnonymousEventHandler("gmcp.Char.player.xpForCurrentLevel", function()
         PRSstats.xp.current = gmcp.Char.player.xp - gmcp.Char.player.xpForCurrentLevel
         PRSstats.xp.tnl = gmcp.Char.player.xpForNextLevel - gmcp.Char.player.xpForCurrentLevel
       end)
       
-      echo("reaching third handler registration\n")
       if PRSstats.events.xpForNextLevel_id then killAnonymousEventHandler(PRSstats.events.xpForNextLevel_id) end
       PRSstats.events.xpForNextLevel_id = registerAnonymousEventHandler("gmcp.Char.player.xpForNextLevel", function()
         PRSstats.xp.tnl = gmcp.Char.player.xpForNextLevel - gmcp.Char.player.xpForCurrentLevel
       end)
-      
-      echo("done with registration\n")
   end
 end
 

--- a/prs-stats.lua
+++ b/prs-stats.lua
@@ -1,9 +1,5 @@
 PRSstats = PRSstats or {}
 PRSstats.events = PRSstats.events or {}
-PRSstats.xp = PRSstats.xp or {}
-PRSstats.xp.current = PRSstats.xp.current or 50
-PRSstats.xp.tnl = PRSstats.xp.tnl or 100
-
 
 local SUG = require("PRS.sug")
 
@@ -189,6 +185,11 @@ local function add_gauges()
   
   -- Experience Points Gauge
   if gmcp.Char.player.xpForNextLevel then
+      
+    PRSstats.xp = PRSstats.xp or {}
+    PRSstats.xp.current = gmcp.Char.player.xp - gmcp.Char.player.xpForCurrentLevel
+    PRSstats.xp.tnl = gmcp.Char.player.xpForNextLevel - gmcp.Char.player.xpForCurrentLevel
+      
     XPbar = SUG:new({
       name = "XP",
       y = 220,
@@ -218,21 +219,27 @@ local function add_gauges()
         font-weight: bold;
         padding-left: 5px;
       ]])
+      
+      echo("reaching first handler registration\n")
       if PRSstats.events.xp_id then killAnonymousEventHandler(PRSstats.events.xp_id) end
       PRSstats.events.xp_id = registerAnonymousEventHandler("gmcp.Char.player.xp", function()
         PRSstats.xp.current = gmcp.Char.player.xp - gmcp.Char.player.xpForCurrentLevel
       end)
       
+      echo("reaching second handler registration\n")
       if PRSstats.events.xpForCurrentLevel_id then killAnonymousEventHandler(PRSstats.events.xpForCurrentLevel_id) end
       PRSstats.events.xpForCurrentLevel_id = registerAnonymousEventHandler("gmcp.Char.player.xpForCurrentLevel", function()
         PRSstats.xp.current = gmcp.Char.player.xp - gmcp.Char.player.xpForCurrentLevel
         PRSstats.xp.tnl = gmcp.Char.player.xpForNextLevel - gmcp.Char.player.xpForCurrentLevel
       end)
       
+      echo("reaching third handler registration\n")
       if PRSstats.events.xpForNextLevel_id then killAnonymousEventHandler(PRSstats.events.xpForNextLevel_id) end
       PRSstats.events.xpForNextLevel_id = registerAnonymousEventHandler("gmcp.Char.player.xpForNextLevel", function()
         PRSstats.xp.tnl = gmcp.Char.player.xpForNextLevel - gmcp.Char.player.xpForCurrentLevel
       end)
+      
+      echo("done with registration\n")
   end
 end
 

--- a/prs-stats.lua
+++ b/prs-stats.lua
@@ -176,33 +176,35 @@ local function add_gauges()
     ]])  
     
   -- Experience Points Gauge
-  XPbar = SUG:new({
-    name = "XP",
-    y = 220,
-    height = 25,
-    width = "95%",
-    updateTime = 250, 
-    textTemplate = "XP: |c / |m   (|p%)",
-    currentVariable = "PRSstats.xp.current",
-    maxVariable = "PRSstats.xp.tnl"
-  }, PRSstats.UW)
-    XPbar.front:setStyleSheet([[background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #3399ff, stop: 0.1 #0080ff, stop: 0.49 #0000ff, stop: 0.5 #0000cc, stop: 1 #0000ff);
-      border-top: 1px black solid;
-      border-left: 1px black solid;
-      border-bottom: 1px black solid;
-      border-radius: 7;
-      padding: 3px;
-    ]])
-    XPbar.back:setStyleSheet([[background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #0066cc, stop: 0.1 #004c99, stop: 0.49 #000099, stop: 0.5 #000066, stop: 1 #000099);
-      border-width: 1px;
-      border-color: black;
-      border-style: solid;
-      border-radius: 7;
-      padding: 3px;
-    ]])
-    XPbar.text:setStyleSheet([[
-      font-weight: bold;
-    ]])
+  if gmcp.Char.player.xp < gmcp.Char.player.xpForCurrentLevel then
+    XPbar = SUG:new({
+      name = "XP",
+      y = 220,
+      height = 25,
+      width = "95%",
+      updateTime = 250, 
+      textTemplate = "XP: |c / |m   (|p%)",
+      currentVariable = "PRSstats.xp.current",
+      maxVariable = "PRSstats.xp.tnl"
+    }, PRSstats.UW)
+      XPbar.front:setStyleSheet([[background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #3399ff, stop: 0.1 #0080ff, stop: 0.49 #0000ff, stop: 0.5 #0000cc, stop: 1 #0000ff);
+        border-top: 1px black solid;
+        border-left: 1px black solid;
+        border-bottom: 1px black solid;
+        border-radius: 7;
+        padding: 3px;
+      ]])
+      XPbar.back:setStyleSheet([[background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #0066cc, stop: 0.1 #004c99, stop: 0.49 #000099, stop: 0.5 #000066, stop: 1 #000099);
+        border-width: 1px;
+        border-color: black;
+        border-style: solid;
+        border-radius: 7;
+        padding: 3px;
+      ]])
+      XPbar.text:setStyleSheet([[
+        font-weight: bold;
+      ]])
+    end
 end
 
 function PRSstats.stats()

--- a/prs-stats.lua
+++ b/prs-stats.lua
@@ -13,7 +13,8 @@ local function add_gauges()
     name = "HP",
     height = 25,
     width = "95%", -- everything up to here is standard Geyser.Gauge
-    updateTime = 250, -- this timer will update every 250ms, or 4 times a second
+    updateTime = 0,
+    updateEvent = "gmcp.Char.player", 
     textTemplate = "HP: |c / |m  (|p%)", -- gauge will show "HP: 500/1000 (50%)" as the text if you had 500 current and 1000 max hp
     currentVariable = "gmcp.Char.player.hp", --if gmcp.Char.Vitals.hp is nil or unreachable, it will use the defaultCurrent of 50
     maxVariable = "gmcp.Char.player.maxHp",  --if gmcp.Char.Vitals.maxhp is nil or unreachable, it will use the defaultMax of 100
@@ -34,6 +35,7 @@ local function add_gauges()
     ]])
     HPbar.text:setStyleSheet([[
       font-weight: bold;
+      padding-left: 5px;
     ]])
 
   -- Energy Points Gauge
@@ -42,7 +44,8 @@ local function add_gauges()
     y = 45,
     height = 25,
     width = "95%", 
-    updateTime = 250, 
+    updateTime = 0,
+    updateEvent = "gmcp.Char.player",
     textTemplate = "EN: |c / |m  (|p%)",
     currentVariable = "gmcp.Char.player.energy",
     maxVariable = "gmcp.Char.player.maxEnergy",
@@ -63,6 +66,7 @@ local function add_gauges()
     ]])
     ENbar.text:setStyleSheet([[
       font-weight: bold;
+      padding-left: 5px;
     ]])
 
   -- Stamina Points Gauge
@@ -71,7 +75,8 @@ local function add_gauges()
     y = 80,
     height = 25,
     width = "95%", 
-    updateTime = 250, 
+    updateTime = 0,
+    updateEvent = "gmcp.Char.player", 
     textTemplate = "ST: |c / |m  (|p%)",
     currentVariable = "gmcp.Char.player.stamina",
     maxVariable = "gmcp.Char.player.maxStamina",
@@ -90,6 +95,7 @@ local function add_gauges()
       padding: 3px;]])
     STbar.text:setStyleSheet([[
       font-weight: bold;
+      padding-left: 5px;
     ]])
 
     -- Food Points Gauge
@@ -98,7 +104,8 @@ local function add_gauges()
     y = 115,
     height = 25,
     width = "95%",
-    updateTime = 250,
+    updateTime = 0,
+    updateEvent = "gmcp.Char.player", 
     textTemplate = "Food: |c / |m  (|p%)",
     currentVariable = "gmcp.Char.player.food",
     maxVariable = "gmcp.Char.player.maxFood",
@@ -119,6 +126,7 @@ local function add_gauges()
     ]])
     HPbar.text:setStyleSheet([[
       font-weight: bold;
+      padding-left: 5px;
     ]])
 
     -- Rage Points Gauge
@@ -127,7 +135,8 @@ local function add_gauges()
     y = 150,
     height = 25,
     width = "95%", 
-    updateTime = 250, 
+    updateTime = 0,
+    updateEvent = "gmcp.Char.player", 
     textTemplate = "Rage: |c",
     currentVariable = "gmcp.Char.player.rage",
     maxVariable = "gmcp.Char.player.maxRage",
@@ -146,6 +155,7 @@ local function add_gauges()
         padding: 3px;]])
     RPbar.text:setStyleSheet([[
       font-weight: bold;
+      padding-left: 5px;
     ]])
 
   -- Combo Points Gauge
@@ -154,7 +164,8 @@ local function add_gauges()
     y = 185,
     height = 25,
     width = "95%", 
-    updateTime = 250, 
+    updateTime = 0,
+    updateEvent = "gmcp.Char.player", 
     textTemplate = "Combo: |c",
     currentVariable = "gmcp.Char.player.combo",
     maxVariable = "gmcp.Char.player.maxCombo",
@@ -173,16 +184,18 @@ local function add_gauges()
         padding: 3px;]])
     CPbar.text:setStyleSheet([[
       font-weight: bold;
+      padding-left: 5px;
     ]])  
-    
+  
   -- Experience Points Gauge
-  if xpForNextLevel then
+  if gmcp.Char.player.xpForNextLevel then
     XPbar = SUG:new({
       name = "XP",
       y = 220,
       height = 25,
       width = "95%",
-      updateTime = 250, 
+      updateTime = 0,
+      updateEvent = "gmcp.Char.player", 
       textTemplate = "XP: |c / |m   (|p%)",
       currentVariable = "PRSstats.xp.current",
       maxVariable = "PRSstats.xp.tnl"
@@ -203,14 +216,30 @@ local function add_gauges()
       ]])
       XPbar.text:setStyleSheet([[
         font-weight: bold;
+        padding-left: 5px;
       ]])
-    end
+      if PRSstats.events.xp_id then killAnonymousEventHandler(PRSstats.events.xp_id) end
+      PRSstats.events.xp_id = registerAnonymousEventHandler("gmcp.Char.player.xp", function()
+        PRSstats.xp.current = gmcp.Char.player.xp - gmcp.Char.player.xpForCurrentLevel
+      end)
+      
+      if PRSstats.events.xpForCurrentLevel_id then killAnonymousEventHandler(PRSstats.events.xpForCurrentLevel_id) end
+      PRSstats.events.xpForCurrentLevel_id = registerAnonymousEventHandler("gmcp.Char.player.xpForCurrentLevel", function()
+        PRSstats.xp.current = gmcp.Char.player.xp - gmcp.Char.player.xpForCurrentLevel
+        PRSstats.xp.tnl = gmcp.Char.player.xpForNextLevel - gmcp.Char.player.xpForCurrentLevel
+      end)
+      
+      if PRSstats.events.xpForNextLevel_id then killAnonymousEventHandler(PRSstats.events.xpForNextLevel_id) end
+      PRSstats.events.xpForNextLevel_id = registerAnonymousEventHandler("gmcp.Char.player.xpForNextLevel", function()
+        PRSstats.xp.tnl = gmcp.Char.player.xpForNextLevel - gmcp.Char.player.xpForCurrentLevel
+      end)
+  end
 end
 
 function PRSstats.stats()
   PRSstats.UW = Geyser.UserWindow:new({name = "Stats", titleText ="Vitals", x = "75%", y = "75%", height="25%", width="25%", docked = true, restoreLayout = true})
   
-  if gmcp and gmcp.Char and gmcp.Char.Vitals then
+  if gmcp and gmcp.Char and gmcp.Char.player then
     PRSstats.UW:setTitle("Vitals - "..gmcp.Char.player.name)
     add_gauges()
   else
@@ -220,19 +249,3 @@ function PRSstats.stats()
     end, true)
   end
 end
-
-if PRSstats.events.xp_id then killAnonymousEventHandler(PRSstats.events.xp_id) end
-PRSstats.events.xp_id = registerAnonymousEventHandler("gmcp.Char.player.xp", function()
-  PRSstats.xp.current = gmcp.Char.player.xp - gmcp.Char.player.xpForCurrentLevel
-end)
-
-if PRSstats.events.xpForCurrentLevel_id then killAnonymousEventHandler(PRSstats.events.xpForCurrentLevel_id) end
-PRSstats.events.xpForCurrentLevel_id = registerAnonymousEventHandler("gmcp.Char.player.xpForCurrentLevel", function()
-  PRSstats.xp.current = gmcp.Char.player.xp - gmcp.Char.player.xpForCurrentLevel
-  PRSstats.xp.tnl = gmcp.Char.player.xpForNextLevel - gmcp.Char.player.xpForCurrentLevel
-end)
-
-if PRSstats.events.xpForNextLevel_id then killAnonymousEventHandler(PRSstats.events.xpForNextLevel_id) end
-PRSstats.events.xpForNextLevel_id = registerAnonymousEventHandler("gmcp.Char.player.xpForNextLevel", function()
-  PRSstats.xp.tnl = gmcp.Char.player.xpForNextLevel - gmcp.Char.player.xpForCurrentLevel
-end)

--- a/prs-stats.lua
+++ b/prs-stats.lua
@@ -176,7 +176,7 @@ local function add_gauges()
     ]])  
     
   -- Experience Points Gauge
-  if gmcp.Char.player.xp < gmcp.Char.player.xpForCurrentLevel then
+  if xpForNextLevel then
     XPbar = SUG:new({
       name = "XP",
       y = 220,


### PR DESCRIPTION
These changes enable automatic position loading via the relevant APIs for Chat and Stats and also move window initialization until after GMCP data has been received to 1) eliminate some errors polluting the log at startup from the various bars based on GMCP data, and 2) allow for the Chat title to reflect the player name (I found a way to change the title for Stats but not for Chat). They also add command lines to the various chat boxes allowing responses in those windows (rather than using the normal command line - so, e.g., you can chat by typing your message directly into the Chat command line).