### PR TITLE
Fixing #74 by adding guards around chat triggers

### DIFF
--- a/prs-chat.lua
+++ b/prs-chat.lua
@@ -87,35 +87,41 @@ function PRSchat.initialize()
     PRSchat.triggers.chat_trigger_id = tempRegexTrigger("^< Chat \\| (?<sender>.+) > (?<msg>.+)$", function()
       local chat_lines = {}
   
-      PRSchat.triggers.chat_line_id = tempRegexTrigger(".*", function()
-        if isPrompt() then
-          local concat_lines = table.concat(chat_lines)
-          local result = concat_lines:sub(1, -2).."\n"
-  
-          PRSchat.EMCO:decho("Chat", result, false)
-          killTrigger(PRSchat.triggers.chat_line_id)
-        else
-          table.insert(chat_lines, copy2decho().." ")
-        end
-      end)
+      if not PRSchat.triggers.chat_line_id then
+        PRSchat.triggers.chat_line_id = tempRegexTrigger(".*", function()
+          if isPrompt() then
+            local concat_lines = table.concat(chat_lines)
+            local result = concat_lines:sub(1, -2).."\n"
+    
+            PRSchat.EMCO:decho("Chat", result, false)
+            killTrigger(PRSchat.triggers.chat_line_id)
+            PRSchat.triggers.chat_line_id = nil
+          else
+            table.insert(chat_lines, copy2decho().." ")
+          end
+        end)
+      end
     end)
   end
 
   if not PRSchat.triggers.newbie_trigger_id then
     PRSchat.triggers.newbie_trigger_id = tempRegexTrigger("^< Newbie \\| (?<sender>.+) > (?<msg>.+)$", function()
       local chat_lines = {}
-  
-      PRSchat.triggers.newbie_line_id = tempRegexTrigger(".*", function()
-        if isPrompt() then
-          local concat_lines = table.concat(chat_lines)
-          local result = concat_lines:sub(1, -2).."\n"
-  
-          PRSchat.EMCO:decho("Newbie", result, false)
-          killTrigger(PRSchat.triggers.newbie_line_id)
-        else
-          table.insert(chat_lines, copy2decho().." ")
-        end
-      end)
+      
+      if not PRSchat.triggers.newbie_line_id then
+        PRSchat.triggers.newbie_line_id = tempRegexTrigger(".*", function()
+          if isPrompt() then
+            local concat_lines = table.concat(chat_lines)
+            local result = concat_lines:sub(1, -2).."\n"
+    
+            PRSchat.EMCO:decho("Newbie", result, false)
+            killTrigger(PRSchat.triggers.newbie_line_id)
+            PRSchat.triggers.newbie_line_id = nil
+          else
+            table.insert(chat_lines, copy2decho().." ")
+          end
+        end)
+      end
     end)
   end
 
@@ -123,17 +129,20 @@ function PRSchat.initialize()
     PRSchat.triggers.trade_trigger_id = tempRegexTrigger("^< Trade \\| (?<sender>.+) > (?<msg>.+)$", function()
       local chat_lines = {}
   
-      PRSchat.triggers.trade_line_id = tempRegexTrigger(".*", function()
-        if isPrompt() then
-          local concat_lines = table.concat(chat_lines)
-          local result = concat_lines:sub(1, -2).."\n"
-  
-          PRSchat.EMCO:decho("Trade", result, false)
-          killTrigger(PRSchat.triggers.trade_line_id)
-        else
-          table.insert(chat_lines, copy2decho().." ")
-        end
-      end)
+      if not PRSchat.triggers.trade_line_id then
+        PRSchat.triggers.trade_line_id = tempRegexTrigger(".*", function()
+          if isPrompt() then
+            local concat_lines = table.concat(chat_lines)
+            local result = concat_lines:sub(1, -2).."\n"
+    
+            PRSchat.EMCO:decho("Trade", result, false)
+            killTrigger(PRSchat.triggers.trade_line_id)
+            PRSchat.triggers.trade_line_id = nil
+          else
+            table.insert(chat_lines, copy2decho().." ")
+          end
+        end)
+      end
     end)
   end
 
@@ -141,33 +150,39 @@ function PRSchat.initialize()
     PRSchat.triggers.local_trigger_id = tempRegexTrigger("^(?<sender>.+) say(?<s>s)?, '(?<msg>.+)$", function()
       local chat_lines = {}
   
-      PRSchat.triggers.local_line_id = tempRegexTrigger(".+", function()
-        table.insert(chat_lines, copy2decho().." ")
-        if string.ends(line, "'") then
-          local concat_lines = table.concat(chat_lines)
-          local result = concat_lines:sub(1, -2).."\n"
-  
-          PRSchat.EMCO:decho("Local", result, false)
-          killTrigger(PRSchat.triggers.local_line_id)
-        end
-      end)
+      if not PRSchat.triggers.local_line_id then
+        PRSchat.triggers.local_line_id = tempRegexTrigger(".+", function()
+          table.insert(chat_lines, copy2decho().." ")
+          if string.ends(line, "'") then
+            local concat_lines = table.concat(chat_lines)
+            local result = concat_lines:sub(1, -2).."\n"
+    
+            PRSchat.EMCO:decho("Local", result, false)
+            killTrigger(PRSchat.triggers.local_line_id)
+            PRSchat.triggers.local_line_id = nil
+          end
+        end)
+      end
     end)
   end
 
   if not PRSchat.triggers.tell_trigger_id then
     PRSchat.triggers.tell_trigger_id = tempRegexTrigger("^(?<from>.+) tell(?<s>s)? (?<to>\\w+), '(?<msg>.+)$", function()
       local chat_lines = {}
-  
-      PRSchat.triggers.tell_line_id = tempRegexTrigger(".+", function()
-        table.insert(chat_lines, copy2decho().." ")
-        if string.ends(line, "'") then
-          local concat_lines = table.concat(chat_lines)
-          local result = concat_lines:sub(1, -2).."\n"
-  
-          PRSchat.EMCO:decho("Tell", result, false)
-          killTrigger(PRSchat.triggers.tell_line_id)
-        end
-      end)
+      
+      if not PRSchat.triggers.tell_line_id then
+        PRSchat.triggers.tell_line_id = tempRegexTrigger(".+", function()
+          table.insert(chat_lines, copy2decho().." ")
+          if string.ends(line, "'") then
+            local concat_lines = table.concat(chat_lines)
+            local result = concat_lines:sub(1, -2).."\n"
+    
+            PRSchat.EMCO:decho("Tell", result, false)
+            killTrigger(PRSchat.triggers.tell_line_id)
+            PRSchat.triggers.tell_line_id = nil
+          end
+        end)
+      end
     end)
   end
 end


### PR DESCRIPTION
The output of the history into the buffer is ugly, but this seems to fix the crash.

We could either include the newlines from the main window and have line wrap ugliness in normal use, live with this, or add logic to try detecting a new chat message and add a newline conditionally.