### PR TITLE
fix(stats): 🐛 add check to xpForNextLevel

### DIFF
--- a/prs-stats.lua
+++ b/prs-stats.lua
@@ -233,7 +233,9 @@ local function add_gauges()
       
       if PRSstats.events.xpForNextLevel_id then killAnonymousEventHandler(PRSstats.events.xpForNextLevel_id) end
       PRSstats.events.xpForNextLevel_id = registerAnonymousEventHandler("gmcp.Char.player.xpForNextLevel", function()
-        PRSstats.xp.tnl = gmcp.Char.player.xpForNextLevel - gmcp.Char.player.xpForCurrentLevel
+        if gmcp.Char.player.xpForNextLevel then
+          PRSstats.xp.tnl = gmcp.Char.player.xpForNextLevel - gmcp.Char.player.xpForCurrentLevel
+        end
       end)
   end
 end


### PR DESCRIPTION
This will hopefully fix #70. However, I don't have a good way to test it. With this the xp bar should stay still after hitting 100 and disappear during the next login.