### PR TITLE
Potential fix for #63

### DIFF
--- a/prs-stats.lua
+++ b/prs-stats.lua
@@ -246,8 +246,10 @@ function PRSstats.stats()
     add_gauges()
   else
     local initialize_ev_handler = registerAnonymousEventHandler("gmcp.Char.player", function()
-      PRSstats.UW:setTitle("Vitals - "..gmcp.Char.player.name)
-      add_gauges()
+      if gmcp and gmcp.Char and gmcp.Char.player and gmcp.Char.player.name then
+        PRSstats.UW:setTitle("Vitals - "..gmcp.Char.player.name)
+        add_gauges()
+      end
     end, true)
   end
 end


### PR DESCRIPTION
Adds a check to make sure the GMCP data includes what it should on login. I don't have a good way to test this, but my assumption is they received GMCP data on login that did not include a refresh.